### PR TITLE
Add Dockerfile and GHCR publish workflow

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,15 @@
+**/bin/
+**/obj/
+**/publish/
+**/.vs/
+**/.idea/
+**/.vscode/
+**/*.user
+.git/
+.github/
+.gitignore
+README.md
+LICENSE
+Dockerfile
+.dockerignore
+myapp/

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,47 @@
+name: Build and publish Docker image to GHCR
+
+on:
+  push:
+    branches: [ main ]
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Lowercase image name
+        id: image
+        run: echo "name=${IMAGE_NAME,,}" >> "$GITHUB_OUTPUT"
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          tags: |
+            ${{ env.REGISTRY }}/${{ steps.image.outputs.name }}:latest
+            ${{ env.REGISTRY }}/${{ steps.image.outputs.name }}:${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
+WORKDIR /src
+
+COPY AspNetCoreSample.sln ./
+COPY AspNetCoreSample/AspNetCoreSample.csproj AspNetCoreSample/
+COPY AspNetCoreSample.Logic/AspNetCoreSample.Logic.csproj AspNetCoreSample.Logic/
+COPY AspNetCoreSample.Logic.Tests/AspNetCoreSample.Logic.Tests.csproj AspNetCoreSample.Logic.Tests/
+COPY AspNetCoreSample.Outbound/AspNetCoreSample.Outbound.csproj AspNetCoreSample.Outbound/
+RUN dotnet restore AspNetCoreSample/AspNetCoreSample.csproj
+
+COPY . .
+RUN dotnet publish AspNetCoreSample/AspNetCoreSample.csproj \
+    --configuration Release \
+    --no-restore \
+    --output /app/publish
+
+FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS runtime
+WORKDIR /app
+COPY --from=build /app/publish .
+
+ENV ASPNETCORE_URLS=http://+:8080
+EXPOSE 8080
+
+ENTRYPOINT ["dotnet", "AspNetCoreSample.dll"]


### PR DESCRIPTION
## Summary
- Multi-stage `Dockerfile` builds the app on `dotnet/sdk:8.0` and runs it on `dotnet/aspnet:8.0` (port 8080)
- New `.github/workflows/docker-publish.yml` builds and pushes to `ghcr.io/${repo}` tagged `:latest` and `:<sha>` on pushes to `main` (uses built-in `GITHUB_TOKEN`, no secrets needed)
- `.dockerignore` keeps `bin/`, `obj/`, and IDE folders out of the build context

## Test plan
- [ ] Merge triggers the workflow and the `build-and-push` job succeeds
- [ ] Image appears under repo Packages with `latest` and commit-sha tags
- [ ] `docker run -p 8080:8080 ghcr.io/mstroppel/asp-net-core-ci-cd:latest` serves `/weatherforecast`

Note: the existing Azure Web App `publish.yml` workflow is unchanged and will continue to run on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)