### PR TITLE
Bump Docker images to .NET 10

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -7,7 +7,7 @@
             "type": "process",
             "args": [
                 "build",
-                "${workspaceFolder}/AspNetCoreSample/AspNetCoreSample.csproj",
+                "${workspaceFolder}/AspNetCoreSample.sln",
                 "/property:GenerateFullPaths=true",
                 "/consoleloggerparameters:NoSummary;ForceNoAlign"
             ],
@@ -18,12 +18,12 @@
             }
         },
         {
-            "label": "build-solution",
+            "label": "build-web",
             "command": "dotnet",
             "type": "process",
             "args": [
                 "build",
-                "${workspaceFolder}/AspNetCoreSample.sln",
+                "${workspaceFolder}/AspNetCoreSample/AspNetCoreSample.csproj",
                 "/property:GenerateFullPaths=true",
                 "/consoleloggerparameters:NoSummary;ForceNoAlign"
             ],

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
 WORKDIR /src
 
 COPY AspNetCoreSample.sln ./
@@ -14,7 +14,7 @@ RUN dotnet publish AspNetCoreSample/AspNetCoreSample.csproj \
     --no-restore \
     --output /app/publish
 
-FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS runtime
+FROM mcr.microsoft.com/dotnet/aspnet:10.0 AS runtime
 WORKDIR /app
 COPY --from=build /app/publish .
 


### PR DESCRIPTION
## Summary
- Update `Dockerfile` to use `mcr.microsoft.com/dotnet/sdk:10.0` and `mcr.microsoft.com/dotnet/aspnet:10.0`
- Fixes the GHCR publish workflow which failed after the .NET 10 upgrade with `NETSDK1045: The current .NET SDK does not support targeting .NET 10.0`

Failing run: https://github.com/mstroppel/asp-net-core-ci-cd/actions/runs/24825783939/job/72661247907

## Test plan
- [ ] GHCR publish workflow runs green on merge to main
- [ ] Resulting container image boots and serves `/weatherforecast`

🤖 Generated with [Claude Code](https://claude.com/claude-code)