### PR TITLE
Update GitHub Actions for Node 24

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -11,9 +11,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Setup dotnet 10.x
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: ${{ env.DOTNET_VERSION }}
       - name: Display dotnet version
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Build Bicep template
         run: az bicep build --file infra/main.bicep
       - name: Build Bicep parameters

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,6 +10,7 @@ env:
   AZURE_RESOURCE_GROUP: dev-marco
   AZURE_WEBAPP_NAME: wa-aspnet-core-ci-demo
   AZURE_WEBAPP_PACKAGE_PATH: 'AspNetCoreSample'
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 permissions:
   id-token: write
@@ -20,10 +21,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: ${{ env.DOTNET_VERSION }}
 
@@ -34,19 +35,22 @@ jobs:
             --output ${{ env.AZURE_WEBAPP_PACKAGE_PATH }}/publish
 
       - name: Azure login (OIDC)
-        uses: azure/login@v2
+        uses: azure/login@v3
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
       - name: Deploy infrastructure (Bicep)
-        uses: azure/arm-deploy@v2
+        uses: azure/bicep-deploy@v2
         with:
-          scope: resourcegroup
-          resourceGroupName: ${{ env.AZURE_RESOURCE_GROUP }}
-          template: ./infra/main.bicep
-          parameters: ./infra/main.bicepparam
+          type: deployment
+          operation: create
+          scope: resourceGroup
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+          resource-group-name: ${{ env.AZURE_RESOURCE_GROUP }}
+          template-file: ./infra/main.bicep
+          parameters-file: ./infra/main.bicepparam
 
       - name: Deploy web app
         uses: azure/webapps-deploy@v3


### PR DESCRIPTION
## Summary
- upgrade workflow actions to Node 24-ready major versions
- replace deprecated azure/arm-deploy with azure/bicep-deploy
- opt the Azure publish workflow into Node 24 now to catch runtime regressions early

## Validation
- parsed edited workflow YAML files locally
- ran az bicep build --file infra/main.bicep
- ran az bicep build-params --file infra/main.bicepparam
- previously verified dotnet build and dotnet test pass locally

## Warning addressed
This removes the Node 20 deprecation warning for checkout/setup-dotnet/login and replaces the legacy ARM deploy action that was also emitting Node deprecation warnings such as punycode, Buffer(), and url.parse().