### PR TITLE
feat: add GET /weatherforecast/tomorrow route

### DIFF
--- a/AspNetCoreSample.Logic.Tests/WeatherForecastAutomoqTests.cs
+++ b/AspNetCoreSample.Logic.Tests/WeatherForecastAutomoqTests.cs
@@ -20,4 +20,22 @@ public class WeatherForecastAutomoqTests
 
         actual.Should().HaveCount(5);
     }
+
+    [Fact]
+    public void GetTomorrowForecast_ShouldReturnTomorrowsForecast()
+    {
+        var tomorrow = DateOnly.FromDateTime(DateTime.Now.AddDays(1));
+        var storageMock = new Mock<IForecastStorage>();
+
+        storageMock.Setup(s => s.GetForecast(tomorrow))
+            .Returns(new OutboundWeatherForecast(tomorrow, 20, "Cloudy"));
+
+        var uut = new WeatherForecastService(storageMock.Object);
+
+        var actual = uut.GetTomorrowForecast();
+
+        actual.Date.Should().Be(tomorrow);
+        actual.TemperatureC.Should().Be(20);
+        actual.Summary.Should().Be("Cloudy");
+    }
 }

--- a/AspNetCoreSample.Logic.Tests/WeatherForecastManualMockTest.cs
+++ b/AspNetCoreSample.Logic.Tests/WeatherForecastManualMockTest.cs
@@ -15,6 +15,18 @@ public class WeatherForecastManualMockTest
         actual.Should().HaveCount(5);
     }
 
+    [Fact]
+    public void GetTomorrowForecast_ShouldReturnTomorrowsForecast()
+    {
+        var uut = new WeatherForecastService(new ForecastStorageMock());
+
+        var actual = uut.GetTomorrowForecast();
+
+        actual.Date.Should().Be(DateOnly.FromDateTime(DateTime.Now.AddDays(1)));
+        actual.TemperatureC.Should().Be(25);
+        actual.Summary.Should().Be("Sunny");
+    }
+
     public class ForecastStorageMock : IForecastStorage
     {
         public OutboundWeatherForecast GetForecast(DateOnly date)

--- a/AspNetCoreSample.Logic/IWeatherForecastService.cs
+++ b/AspNetCoreSample.Logic/IWeatherForecastService.cs
@@ -3,4 +3,5 @@
 public interface IWeatherForecastService
 {
     IEnumerable<WeatherForecast> GetForecasts();
+    WeatherForecast GetTomorrowForecast();
 }

--- a/AspNetCoreSample.Logic/WeatherForecastService.cs
+++ b/AspNetCoreSample.Logic/WeatherForecastService.cs
@@ -16,4 +16,11 @@ public class WeatherForecastService(IForecastStorage forecastStorage) : IWeather
         });
         return forecasts;
     }
+
+    public WeatherForecast GetTomorrowForecast()
+    {
+        var tomorrow = DateOnly.FromDateTime(DateTime.Now.AddDays(1));
+        var forecast = _forecastStorage.GetForecast(tomorrow);
+        return new WeatherForecast(tomorrow, forecast.TemperatureC, forecast.Summary);
+    }
 }

--- a/AspNetCoreSample/Program.cs
+++ b/AspNetCoreSample/Program.cs
@@ -22,4 +22,11 @@ app.MapGet("/weatherforecast", (IWeatherForecastService weatherForecastService) 
     })
     .WithName("GetWeatherForecast");
 
+app.MapGet("/weatherforecast/tomorrow", (IWeatherForecastService weatherForecastService) =>
+    {
+        var forecast = weatherForecastService.GetTomorrowForecast();
+        return forecast;
+    })
+    .WithName("GetTomorrowWeatherForecast");
+
 app.Run();


### PR DESCRIPTION
## Summary
- Adds `GetTomorrowForecast()` to `IWeatherForecastService` and `WeatherForecastService`
- Exposes a new `GET /weatherforecast/tomorrow` endpoint returning the forecast for the next day

## Test plan
- [ ] Build passes (`dotnet build`)
- [ ] `GET /weatherforecast/tomorrow` returns a single `WeatherForecast` for tomorrow's date

Closes #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)